### PR TITLE
Add basic support for Vue SFC files (as HTML)

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -10,6 +10,7 @@ const extensionToPrismLanguageMap = new Map([
 
     // Common files
     ['Vagrantfile', 'ruby'],
+    ['vue', 'html'],
 ])
 
 runWhenUrlChanges(() => {


### PR DESCRIPTION
PrismJS does not support this (https://github.com/PrismJS/prism/issues/1665) but highlighting these files as HTML files would already be a lot better.

The extension of theses files is ".vue"