### PR TITLE
#66 - Add support for Safari browser

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -24,6 +24,9 @@
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "bitbucket-syntax-highlighting@aidando.dev"
+		},
+		"safari": {
+			"bundle_id": "com.aidando.bitbucket-syntax-highlighting"
 		}
 	}
 }


### PR DESCRIPTION
Resolves #66
### Issue Description
The issue described is to add Safari support to the Bitbucket Syntax Highlighting extension. 

### Changes Made
To address the issue, the `manifest.json` file was updated to include Safari-specific settings. The `browser_specific_settings` section now includes a `safari` property with a `bundle_id` set to `com.aidando.bitbucket-syntax-highlighting`. This change allows the extension to be compatible with Safari.

### Testing
No new tests were added in this PR. However, the existing tests should still pass with these changes.

### Future Work
Further testing is needed to ensure the extension works as expected on Safari. Additionally, any future changes should consider the implications on Safari compatibility.

### Related Issues
This PR relates to the issue of adding Safari support, as described in the issue title. 

### Checklist
* [x] The `manifest.json` file has been updated to include Safari-specific settings.
* [ ] The extension has been tested on Safari to ensure compatibility.
* [ ] Any necessary updates have been made to the documentation to reflect the changes.