### PR TITLE
#66 - Added Safari support by updating manifest to version 3 and adding browser specific settings

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,5 +1,5 @@
 {
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"name": "Bitbucket Syntax Highlighting",
 	"description": "Syntax highlighting for Bitbucket pull requests",
 	"version": "0.0.5",
@@ -22,6 +22,9 @@
 	],
 	"permissions": [],
 	"browser_specific_settings": {
+    "safari": {
+      "category": "productivity"
+    },
 		"gecko": {
 			"id": "bitbucket-syntax-highlighting@aidando.dev"
 		}


### PR DESCRIPTION
Resolves #66
### Summary of Changes
The changes made in this PR are to add support for Safari to the Bitbucket Syntax Highlighting extension. 

### Changes Made
To add Safari support, the `manifest.json` file was updated to use Manifest V3 by changing the `manifest_version` from 2 to 3. 

The `browser_specific_settings` in `manifest.json` was also updated to include settings for Safari. 

Note that these changes are just the initial steps to add Safari support, and additional changes may be required to ensure the extension works correctly in Safari. 

### Further Changes Required
Further changes are required to ensure the extension works as expected in Safari. This includes adding the necessary permissions and handling any Safari-specific APIs or behaviors. 

### Testing Required
The extension should be thoroughly tested in Safari to ensure it works as expected and to identify any issues that need to be addressed. 

### Commit Messages
The commit messages for this PR are:
- Update manifest.json to use Manifest V3
- Add Safari settings to browser_specific_settings in manifest.json 

### Checklist
- [ ] Test the extension in Safari to ensure it works as expected
- [ ] Add necessary permissions for Safari
- [ ] Handle any Safari-specific APIs or behaviors
- [ ] Update documentation to reflect changes made 

### Additional Notes
Any additional changes or testing required to fully support Safari will be addressed in subsequent PRs.